### PR TITLE
add comment lexing and tests, initial support of block and line comme…

### DIFF
--- a/src/schema_lexer.xrl
+++ b/src/schema_lexer.xrl
@@ -6,6 +6,8 @@ STRING          = [a-zA-Z0-9_\.]+
 BOOL            = (true|false)
 WS              = [\s\t]+
 NL              = [\n\r]+
+COMMENT         = //.[^\n]*\n
+BLOCK_COMMENT   = /\*[^(\*/)]*\*/
 
 Rules.
 
@@ -26,6 +28,8 @@ file_extension{WS}  : {token, {file_extension, TokenLine}}.
 {STRING}        : {token, {string, TokenLine, TokenChars}}.
 {WS}            : skip_token.
 {NL}            : skip_token.
+{COMMENT}       : skip_token.
+{BLOCK_COMMENT} : skip_token.
 
 \{    : {token, {'{',  TokenLine}}.
 \}    : {token, {'}',  TokenLine}}.
@@ -38,6 +42,7 @@ file_extension{WS}  : {token, {file_extension, TokenLine}}.
 \:    : {token, {':',  TokenLine}}.
 \=    : {token, {'=',  TokenLine}}.
 \"    : {token, {quote, TokenLine}}.
+
 
 Erlang code.
 

--- a/src/schema_lexer.xrl
+++ b/src/schema_lexer.xrl
@@ -6,7 +6,7 @@ STRING          = [a-zA-Z0-9_\.]+
 BOOL            = (true|false)
 WS              = [\s\t]+
 NL              = [\n\r]+
-COMMENT         = //.[^\n]*\n
+COMMENT         = //(.|\n)[^\n]*\n
 BLOCK_COMMENT   = /\*[^(\*/)]*\*/
 
 Rules.

--- a/test/comment_test.exs
+++ b/test/comment_test.exs
@@ -1,0 +1,17 @@
+defmodule EflatbuffersTest.Comments do
+  use ExUnit.Case
+
+  @expected_person {
+    %{:Person => {:table, [name: :string, age: :int]}},
+    %{:root_type => :Person}
+  }
+
+  test "parse file with comments" do
+    res =
+      File.read!("test/schemas/comment_test.fbs")
+      |> Eflatbuffers.Schema.lexer()
+      |> :schema_parser.parse()
+
+    assert {:ok, @expected_person} == res
+  end
+end

--- a/test/schemas/comment_test.fbs
+++ b/test/schemas/comment_test.fbs
@@ -12,3 +12,4 @@ table Person {
 root_type Person;
 
 // EOF COMMENT MUST END WITH NEWLINE
+

--- a/test/schemas/comment_test.fbs
+++ b/test/schemas/comment_test.fbs
@@ -1,0 +1,14 @@
+// Line 1 comment
+
+/// Doc Comment
+table Person {
+    name: string;
+    /*
+    Multiline Comment
+    */
+    age: int;
+}
+
+root_type Person;
+
+// EOF COMMENT MUST END WITH NEWLINE

--- a/test/schemas/comment_test.fbs
+++ b/test/schemas/comment_test.fbs
@@ -1,3 +1,7 @@
+//
+// Header with top/bottom empty comments
+//
+
 // Line 1 comment
 
 /// Doc Comment
@@ -6,10 +10,9 @@ table Person {
     /*
     Multiline Comment
     */
-    age: int;
+    age: int; // Inline comment
 }
 
 root_type Person;
 
 // EOF COMMENT MUST END WITH NEWLINE
-


### PR DESCRIPTION
…nts, abandon all comments before parsing stage.

Adds comments to the lexer and simply skips them. Supports multiline/block and standard line comments.

Caveats:

1. Does not keep documentation comments, they are discarded along with the other comments.
2. File cannot end with a line comment - it must have a final newline character.