### PR TITLE
add includes and tests. ensure includes don't have infinite loops

### DIFF
--- a/lib/eflatbuffers.ex
+++ b/lib/eflatbuffers.ex
@@ -1,10 +1,10 @@
 defmodule Eflatbuffers do
-  def parse_schema(schema_str) do
-    Eflatbuffers.Schema.parse(schema_str)
+  def parse_schema(schema_str, parse_opts \\ %{}) do
+    Eflatbuffers.Schema.parse(schema_str, parse_opts)
   end
 
-  def parse_schema!(schema_str) do
-    case parse_schema(schema_str) do
+  def parse_schema!(schema_str, parse_opts \\ %{}) do
+    case parse_schema(schema_str, parse_opts) do
       {:ok, schema} -> schema
       error -> throw(error)
     end

--- a/lib/eflatbuffers.ex
+++ b/lib/eflatbuffers.ex
@@ -1,9 +1,9 @@
 defmodule Eflatbuffers do
-  def parse_schema(schema_str, parse_opts \\ %{}) do
+  def parse_schema(schema_str, parse_opts \\ []) do
     Eflatbuffers.Schema.parse(schema_str, parse_opts)
   end
 
-  def parse_schema!(schema_str, parse_opts \\ %{}) do
+  def parse_schema!(schema_str, parse_opts \\ []) do
     case parse_schema(schema_str, parse_opts) do
       {:ok, schema} -> schema
       error -> throw(error)

--- a/lib/eflatbuffers/schema.ex
+++ b/lib/eflatbuffers/schema.ex
@@ -14,8 +14,8 @@ defmodule Eflatbuffers.Schema do
     :double
   ]
 
-  def parse!(schema_str) do
-    case parse(schema_str) do
+  def parse!(schema_str, parse_opts \\ []) do
+    case parse(schema_str, parse_opts) do
       {:ok, schema} ->
         schema
 
@@ -24,12 +24,12 @@ defmodule Eflatbuffers.Schema do
     end
   end
 
-  def parse(schema_str) when is_binary(schema_str) do
+  def parse(schema_str, parse_opts \\ []) when is_binary(schema_str) do
     tokens = lexer(schema_str)
 
     case :schema_parser.parse(tokens) do
       {:ok, data} ->
-        {:ok, decorate(data)}
+        {:ok, decorate(data, parse_opts)}
 
       error ->
         error
@@ -44,12 +44,45 @@ defmodule Eflatbuffers.Schema do
     tokens
   end
 
+  def process_includes(entities, options, parse_opts, included_files \\ MapSet.new()) do
+    %{base_path: base_path} = Enum.into(parse_opts, %{base_path: "."})
+
+    includes =
+      Enum.filter(
+        options,
+        fn
+          {:include, _} -> true
+          _ -> false
+        end
+      )
+
+    Enum.reduce(
+      includes,
+      entities,
+      fn
+        {:include, included_file}, acc ->
+          if MapSet.member?(included_files, included_file) do
+            acc
+          else
+            {:ok, {es, options}} =
+              File.read!(Path.join(base_path, included_file)) |> lexer() |> :schema_parser.parse()
+
+            included_files = MapSet.put(included_files, included_file)
+            acc = Map.merge(acc, process_includes(entities, options, parse_opts, included_files))
+            Map.merge(acc, es)
+          end
+      end
+    )
+  end
+
   # this preprocesses the schema
   # in order to keep the read/write
   # code as simple as possible
   # correlate tables with names
   # and define defaults explicitly
-  def decorate({entities, options}) do
+  def decorate({entities, options}, parse_opts \\ []) do
+    entities = process_includes(entities, options, parse_opts)
+
     entities_decorated =
       Enum.reduce(
         entities,

--- a/lib/eflatbuffers/schema.ex
+++ b/lib/eflatbuffers/schema.ex
@@ -45,7 +45,7 @@ defmodule Eflatbuffers.Schema do
   end
 
   def process_includes(entities, options, parse_opts, included_files \\ MapSet.new()) do
-    %{base_path: base_path} = Enum.into(parse_opts, %{base_path: "."})
+    base_path = Keyword.get(parse_opts, :base_path, ".")
 
     includes =
       Enum.filter(

--- a/lib/eflatbuffers/schema.ex
+++ b/lib/eflatbuffers/schema.ex
@@ -47,6 +47,8 @@ defmodule Eflatbuffers.Schema do
   def process_includes(entities, options, parse_opts, included_files \\ MapSet.new()) do
     base_path = Keyword.get(parse_opts, :base_path, ".")
 
+    IO.inspect(options)
+
     includes =
       Enum.filter(
         options,
@@ -55,6 +57,8 @@ defmodule Eflatbuffers.Schema do
           _ -> false
         end
       )
+
+    IO.inspect(includes)
 
     Enum.reduce(
       includes,

--- a/src/schema_parser.yrl
+++ b/src/schema_parser.yrl
@@ -12,7 +12,7 @@ option -> namespace string ';' : #{get_name('$1') => get_value_atom('$2')}.
 option -> root_type string ';' : #{get_name('$1') => get_value_atom('$2')}.
 
 % options (quoted)
-option -> include quote string quote ';'         : #{get_name('$1') => get_value_bin('$3')}.
+option -> include quote string quote ';'         : #{get_name('$1') => [get_value_bin('$3')]}.
 option -> attribute quote string quote ';'       : #{get_name('$1') => get_value_bin('$3')}.
 option -> file_identifier quote string quote ';' : #{get_name('$1') => get_value_bin('$3')}.
 option -> file_extension quote string quote ';'  : #{get_name('$1') => get_value_bin('$3')}.
@@ -53,11 +53,16 @@ atom -> string : get_value_atom('$1').
 Erlang code.
 
 get_value_atom({_Token, _Line, Value}) -> list_to_atom(Value).
-get_value_bin({_Token, _Line, Value})  -> list_to_binary(Value).
-get_value({_Token, _Line, Value})      -> Value.
+get_value_bin({_Token, _Line, Value}) -> list_to_binary(Value).
+get_value({_Token, _Line, Value}) -> Value.
 
-get_name({Token, _Line, _Value})  -> Token;
-get_name({Token, _Line})          -> Token.
+get_name({Token, _Line, _Value}) -> Token;
+get_name({Token, _Line}) -> Token.
 
 add_def({Defs, Opts}, Def) -> {maps:merge(Defs, Def), Opts}.
-add_opt({Defs, Opts}, Opt) -> {Defs, maps:merge(Opts, Opt)}.
+
+add_opt({Defs, Opts}, #{include := _} = Opt) ->
+    Fun = fun(V) -> V ++ maps:get(include, Opt) end,
+    {Defs, maps:update_with(include, Fun, maps:get(include, Opt), Opts)};
+add_opt({Defs, Opts}, Opt) ->
+    {Defs, maps:merge(Opts, Opt)}.

--- a/test/include_test.exs
+++ b/test/include_test.exs
@@ -1,0 +1,49 @@
+defmodule Eflatbuffers.IncludeTest do
+  use ExUnit.Case
+
+  @expected_simple_include_1_child {%{
+                                      Child:
+                                        {:table,
+                                         %{
+                                           fields: [name: {:string, %{}}],
+                                           indices: %{name: {0, {:string, %{}}}}
+                                         }},
+                                      Parent:
+                                        {:table,
+                                         %{
+                                           fields: [child: {:table, %{name: :Child}}],
+                                           indices: %{child: {0, {:table, %{name: :Child}}}}
+                                         }}
+                                    }, %{include: "include_child.fbs", root_type: :Parent}}
+
+  @expected_loop_stopped {%{
+                            LoopB:
+                              {:table,
+                               %{
+                                 fields: [loop_a: {:table, %{name: :LoopA}}],
+                                 indices: %{loop_a: {0, {:table, %{name: :LoopA}}}}
+                               }},
+                            LoopA:
+                              {:table,
+                               %{
+                                 fields: [loop_b: {:table, %{name: :LoopB}}],
+                                 indices: %{loop_b: {0, {:table, %{name: :LoopB}}}}
+                               }}
+                          }, %{include: "include_loop_b.fbs", root_type: :LoopA}}
+
+  test "simple include, 1 child" do
+    schema =
+      File.read!("test/schemas/include_parent.fbs")
+      |> Eflatbuffers.Schema.parse!(%{base_path: "test/schemas"})
+
+    assert @expected_simple_include_1_child == schema
+  end
+
+  test "loop is stopped" do
+    schema =
+      File.read!("test/schemas/include_loop_a.fbs")
+      |> Eflatbuffers.Schema.parse!(%{base_path: "test/schemas"})
+
+    assert schema == @expected_loop_stopped
+  end
+end

--- a/test/include_test.exs
+++ b/test/include_test.exs
@@ -14,8 +14,39 @@ defmodule Eflatbuffers.IncludeTest do
                                            fields: [child: {:table, %{name: :Child}}],
                                            indices: %{child: {0, {:table, %{name: :Child}}}}
                                          }}
-                                    }, %{include: "include_child.fbs", root_type: :Parent}}
+                                    }, %{include: ["include_child.fbs"], root_type: :Parent}}
 
+  @expected_simple_include_2_child {%{
+                                      Child:
+                                        {:table,
+                                         %{
+                                           fields: [name: {:string, %{}}],
+                                           indices: %{name: {0, {:string, %{}}}}
+                                         }},
+                                      Parent: {
+                                        :table,
+                                        %{
+                                          fields: [
+                                            {:child, {:table, %{name: :Child}}},
+                                            {:child2, {:table, %{name: :Child2}}}
+                                          ],
+                                          indices: %{
+                                            child: {0, {:table, %{name: :Child}}},
+                                            child2: {1, {:table, %{name: :Child2}}}
+                                          }
+                                        }
+                                      },
+                                      Child2:
+                                        {:table,
+                                         %{
+                                           fields: [name: {:string, %{}}],
+                                           indices: %{name: {0, {:string, %{}}}}
+                                         }}
+                                    },
+                                    %{
+                                      include: ["include_child.fbs", "include_child2.fbs"],
+                                      root_type: :Parent
+                                    }}
   @expected_loop_stopped {%{
                             LoopB:
                               {:table,
@@ -29,7 +60,7 @@ defmodule Eflatbuffers.IncludeTest do
                                  fields: [loop_b: {:table, %{name: :LoopB}}],
                                  indices: %{loop_b: {0, {:table, %{name: :LoopB}}}}
                                }}
-                          }, %{include: "include_loop_b.fbs", root_type: :LoopA}}
+                          }, %{include: ["include_loop_b.fbs"], root_type: :LoopA}}
 
   test "simple include, 1 child" do
     schema =
@@ -44,9 +75,7 @@ defmodule Eflatbuffers.IncludeTest do
       File.read!("test/schemas/include_parent2.fbs")
       |> Eflatbuffers.Schema.parse!(base_path: "test/schemas")
 
-    IO.inspect(schema)
-
-    assert @expected_simple_include_1_child == schema
+    assert @expected_simple_include_2_child == schema
   end
 
   test "loop is stopped" do

--- a/test/include_test.exs
+++ b/test/include_test.exs
@@ -39,6 +39,16 @@ defmodule Eflatbuffers.IncludeTest do
     assert @expected_simple_include_1_child == schema
   end
 
+  test "simple include, 2 childs" do
+    schema =
+      File.read!("test/schemas/include_parent2.fbs")
+      |> Eflatbuffers.Schema.parse!(base_path: "test/schemas")
+
+    IO.inspect(schema)
+
+    assert @expected_simple_include_1_child == schema
+  end
+
   test "loop is stopped" do
     schema =
       File.read!("test/schemas/include_loop_a.fbs")

--- a/test/include_test.exs
+++ b/test/include_test.exs
@@ -34,7 +34,7 @@ defmodule Eflatbuffers.IncludeTest do
   test "simple include, 1 child" do
     schema =
       File.read!("test/schemas/include_parent.fbs")
-      |> Eflatbuffers.Schema.parse!(%{base_path: "test/schemas"})
+      |> Eflatbuffers.Schema.parse!(base_path: "test/schemas")
 
     assert @expected_simple_include_1_child == schema
   end
@@ -42,7 +42,7 @@ defmodule Eflatbuffers.IncludeTest do
   test "loop is stopped" do
     schema =
       File.read!("test/schemas/include_loop_a.fbs")
-      |> Eflatbuffers.Schema.parse!(%{base_path: "test/schemas"})
+      |> Eflatbuffers.Schema.parse!(base_path: "test/schemas")
 
     assert schema == @expected_loop_stopped
   end

--- a/test/schema_parser_test.exs
+++ b/test/schema_parser_test.exs
@@ -3,7 +3,7 @@ defmodule Eflatbuffers.SchemaTest do
 
   @expected_simple %{
     namespace: :"SyGame.Play",
-    include: "some_other.fbs",
+    include: ["some_other.fbs"],
     attribute: "priority",
     file_identifier: "FOOO",
     file_extension: "baa",

--- a/test/schemas/include_child.fbs
+++ b/test/schemas/include_child.fbs
@@ -1,0 +1,5 @@
+table Child {
+    name: string;
+}
+
+root_type Child;

--- a/test/schemas/include_child2.fbs
+++ b/test/schemas/include_child2.fbs
@@ -1,0 +1,5 @@
+table Child2 {
+    name: string;
+}
+
+root_type Child2;

--- a/test/schemas/include_loop_a.fbs
+++ b/test/schemas/include_loop_a.fbs
@@ -1,0 +1,7 @@
+include "include_loop_b.fbs";
+
+table LoopA {
+    loop_b: LoopB;
+}
+
+root_type LoopA;

--- a/test/schemas/include_loop_b.fbs
+++ b/test/schemas/include_loop_b.fbs
@@ -1,0 +1,7 @@
+include "include_loop_a.fbs";
+
+table LoopB {
+    loop_a: LoopA;
+}
+
+root_type LoopB;

--- a/test/schemas/include_parent.fbs
+++ b/test/schemas/include_parent.fbs
@@ -1,0 +1,6 @@
+include "include_child.fbs";
+
+table Parent {
+  child: Child;
+}
+root_type Parent;

--- a/test/schemas/include_parent2.fbs
+++ b/test/schemas/include_parent2.fbs
@@ -1,0 +1,8 @@
+include "include_child.fbs";
+
+table Parent {
+  child: Child;
+}
+root_type Parent;
+
+include "include_child2.fbs";

--- a/test/schemas/include_parent2.fbs
+++ b/test/schemas/include_parent2.fbs
@@ -2,6 +2,7 @@ include "include_child.fbs";
 
 table Parent {
   child: Child;
+  child2: Child2;
 }
 root_type Parent;
 


### PR DESCRIPTION
Adds includes capability to the `decorate` function to allow for flatbuffer fbs files to include others. Adds two simple tests to ensure infinite loops don't happen when files coreference each other.